### PR TITLE
:sparkles: update cli to Amazon Linux 2.0

### DIFF
--- a/deployment/sagemaker-dashboards-for-ml/cloudformation/development/development.yaml
+++ b/deployment/sagemaker-dashboards-for-ml/cloudformation/development/development.yaml
@@ -232,7 +232,7 @@ Resources:
               pip install --upgrade pip==20.0.2
               pip uninstall -y nbserverproxy || true
               pip install --upgrade jupyter-server-proxy==1.3.2
-              initctl restart jupyter-server --no-wait
+              systemctl restart jupyter-server --no-block
               # create dashboard env
               conda create -y --name dashboard python=3.6 pip ipykernel
               source /home/ec2-user/anaconda3/bin/activate dashboard


### PR DESCRIPTION
*Issue #, if available:*
Notebook Life Cycle Configuration Fails, as the original CLI supports only Amazon Linux 1.0

*Description of changes:*
Update the CLI to support Amazon Linux 2.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
